### PR TITLE
BUGS-297 For endpoints without parameters, dont require the key

### DIFF
--- a/api_test/test_cases.py
+++ b/api_test/test_cases.py
@@ -30,7 +30,7 @@ class GetTestCase(test.TransactionTestCase):
             test_data = dict()
         self.path = path
         self.url = url
-        self.parameters = parameters
+        self.parameters = parameters or []
         self.response = response
         self.test_data = test_data
 

--- a/api_test/test_generator.py
+++ b/api_test/test_generator.py
@@ -26,13 +26,12 @@ def generate_tests(spec_file):
                         continue  # not yet implemented
                     response['status_code'] = int(code)
                     test_cases = get_specification.get('x-test')
+                    parameters = get_specification.get('parameters')
                     if not test_cases:
-                        yield GetTestCase(path_name, url, get_specification['parameters'],
-                                          response)
+                        yield GetTestCase(path_name, url, parameters, response)
                         continue
                     for test_data in test_cases:
-                        case = GetTestCase(path_name, url, get_specification['parameters'],
-                                           response, test_data)
+                        case = GetTestCase(path_name, url, parameters, response, test_data)
                         yield case
     yield False
 


### PR DESCRIPTION
@chhayspothero 

When an endpoint doesnt take parameters in the URL the api test tool will fail. In those cases we shouldn't fail the tests for lacking parameters.
