### PR TITLE
Feature/sh 6574 django 1 9 support

### DIFF
--- a/api_test/api_test_plugin.py
+++ b/api_test/api_test_plugin.py
@@ -15,8 +15,8 @@ logger = logging.getLogger(__name__)
 class ApiTest(Plugin):
     # Test classes
     test_classes = []
-    # This plugin is compatible with Django 1.9 parallel testing
-    parallel_compatible = True
+    # This plugin is incompatible with Django 1.9 parallel testing due to `beforeTest`
+    parallel_compatible = False
 
     def options(self, parser, env):
         """Nosetests use the deprecated OptionParser framework. If running this module as a

--- a/api_test/api_test_plugin.py
+++ b/api_test/api_test_plugin.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from nose.plugins.base import Plugin
 from nose.failure import Failure
 
+from test_cases import GetTestCase
 import test_generator
 
 
@@ -14,21 +15,29 @@ logger = logging.getLogger(__name__)
 class ApiTest(Plugin):
     # Test classes
     test_classes = []
+    # This plugin is compatible with Django 1.9 parallel testing
+    parallel_compatible = True
 
     def options(self, parser, env):
-        Plugin.options(self, parser, env)
-        parser.add_option("--api", dest="api", action="store_true", default=False)
+        """Nosetests use the deprecated OptionParser framework. If running this module as a
+        nose plugin, use `add_option`, otherwise default to the modern ArgParse `add_argument`.
+        """
+        if hasattr(parser, 'add_option'):
+            parser.add_option("--api", dest="api", action="store_true", default=False)
+        else:
+            parser.add_argument("--api", dest="api", action="store_true", default=False)
 
     def configure(self, options, conf):
-        Plugin.configure(self, options, conf)
         self.enabled = options.api
-
-    # def prepareTestRunner(self, runner):
-    #     from api_test.test_tool import TestRunner
-    #     return TestRunner()
 
     def wantFile(self, file):
         if 'yaml' in file:
+            return True
+        return False
+
+    def wantClass(self, cls):
+        """Signal that we want to run test cases which are derivative of `GetTestCase`"""
+        if isinstance(cls, GetTestCase):
             return True
         return False
 

--- a/api_test/test_cases.py
+++ b/api_test/test_cases.py
@@ -34,6 +34,17 @@ class GetTestCase(test.TransactionTestCase):
         self.response = response
         self.test_data = test_data
 
+    def __eq__(self, other):
+        """Django Test Runner uses equality to choose whether or not a test is a duplicate. Simple
+        equality uses the name of the TestClass (`GetTestCase`) and the methodName, which is always
+        `runTest`. As such, The Django test runner will only run a single `GetTestCase` method
+        unless we override equality to include all the details of the given test.
+        """
+        equal = self.path == other.path
+        equal &= self.url == other.url
+        equal &= self.parameters == other.parameters
+        return equal
+
     def runTest(self):
         client = APIClient()
         try:

--- a/api_test/test_generator.py
+++ b/api_test/test_generator.py
@@ -33,7 +33,7 @@ def generate_tests(spec_file):
                     for test_data in test_cases:
                         case = GetTestCase(path_name, url, parameters, response, test_data)
                         yield case
-    yield False
+    yield StopIteration
 
 
 def inline_swagger_refs(target_load_dict, full_swagger):

--- a/api_test/test_generator.py
+++ b/api_test/test_generator.py
@@ -33,7 +33,7 @@ def generate_tests(spec_file):
                     for test_data in test_cases:
                         case = GetTestCase(path_name, url, parameters, response, test_data)
                         yield case
-    yield StopIteration
+    raise StopIteration
 
 
 def inline_swagger_refs(target_load_dict, full_swagger):


### PR DESCRIPTION
@spothero/backend 
This PR introduces support in the API test tool for being run with the Django Test Runner (aka without django-nose) while preserving compatibility with nosetests. I tested this with our Django 1.8 tests as well as everything on Django 1.9