### PR TITLE
select tests by endpoint and tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,20 @@ The tests will use any test data listed in the spec file and compare defined res
 
 This tool currently only supports get requests and 200 responses.
 
-How to run this tool:
-python manage.py test --api <swagger_file.yaml>
+## How to run this tool:
 
-Test Tool Roadmap:
+    python manage.py test --api <swagger_file.yaml> --endpoint-substr=SUBSTRING --tags=TAGS
+
+Both `--endpoint-substr` and `--tags` are optional, and used to select subsets of tests to run.
+
+`SUBSTRING` must be a substring of the endpoint for tests on that endpoint to be run.
+
+`TAGS` is a comma-separated list of tags of tests to run. For example, `--tags=Facilities,Users` will run tests that
+have the `Facilities` tag, and also tests that have the `Users` tag.
+
+
+## Test Tool Roadmap:
+
 - test that all endpoints are documented
 - support all http method requests
 - test for error responses (400, 422, 428...) 
@@ -21,8 +31,6 @@ Test Tool Roadmap:
   - print response with definition as its tested
   - print url and request parameters
 - allow subsets of tests to be selected
-  - select by tag
-  - select by endpoint
   - select by endpoint, type, and response (e.g. /reservations/.get.200)
 - support assert criteria
   - min/max, pattern checking

--- a/api_test/test_generator.py
+++ b/api_test/test_generator.py
@@ -29,7 +29,7 @@ def generate_tests(spec_file, url_substring='', required_tags=None):
 
                 # tag condition: if the current tags match any of the required tags, then we should return it
                 tags = get_specification.get('tags', [])
-                if required_tags and not any(tag in tags for tag in required_tags):
+                if required_tags and not set(tags).intersection(set(required_tags)):
                     # continue on to next path
                     #   (Note: after implementing more HTTP methods besides GET, make sure you go
                     #   on to the next method instead of the next path here)

--- a/api_test/test_generator.py
+++ b/api_test/test_generator.py
@@ -4,17 +4,37 @@ from django.conf import settings
 import yaml_utils
 
 
-def generate_tests(spec_file):
+def generate_tests(spec_file, url_substring='', required_tags=None):
+    if not required_tags:
+        required_tags = []
+
     from test_cases import GetTestCase
 
     with open(spec_file) as spec:
+        # parse yaml spec file into a dict-like object
         spec_nodes = yaml.load(spec)
+
         base_path = spec_nodes['basePath']
         paths = spec_nodes['paths']
+
         for path_name, values in paths.iteritems():
             url = '//' + settings.PARENT_HOST + base_path + path_name
+
+            # url substring condition
+            if url_substring not in url:
+                continue
+
             if 'get' in values.keys():
                 get_specification = values['get']
+
+                # tag condition: if the current tags match any of the required tags, then we should return it
+                tags = get_specification.get('tags', [])
+                if required_tags and not any(tag in tags for tag in required_tags):
+                    # continue on to next path
+                    #   (Note: after implementing more HTTP methods besides GET, make sure you go
+                    #   on to the next method instead of the next path here)
+                    continue
+
                 while 1:
                     loaded = inline_swagger_refs(get_specification, spec_nodes)
                     if not loaded:

--- a/api_test/utils.py
+++ b/api_test/utils.py
@@ -1,5 +1,3 @@
-import collections
-
 type_dict = {
     'array': list,
     'integer': int,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,11 @@
-django==1.8
-djangorestframework==2.3.11
-django-nose==1.4
+Django==1.8
 django-hosts==1.2
+django-nose==1.4
+djangorestframework==2.3.11
+linecache2==1.0.0
+nose==1.3.7
+python-dateutil==2.6.0
+PyYAML==3.12
+six==1.10.0
+traceback2==1.4.0
 unittest2==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ djangorestframework==2.3.11
 nose==1.3.7
 python-dateutil==2.6.0
 PyYAML==3.12
-six==1.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,6 @@
 Django==1.8
-django-hosts==1.2
-django-nose==1.4
 djangorestframework==2.3.11
-linecache2==1.0.0
 nose==1.3.7
 python-dateutil==2.6.0
 PyYAML==3.12
 six==1.10.0
-traceback2==1.4.0
-unittest2==1.1.0


### PR DESCRIPTION
This PR adds command-line options for selecting tests by endpoint (substring match) and/or tag. I needed a way to select subsets of tests to speed up other development I was doing.

please review: @spothero/backend @ash6851 