### PR TITLE
make failures more verbose

### DIFF
--- a/api_test/test_cases.py
+++ b/api_test/test_cases.py
@@ -92,7 +92,7 @@ class GetTestCase(test.TransactionTestCase):
         self.assertEqual(code, self.response['status_code'], msg)
         body = json.loads(content)
 
-        # Catch failures and print more information, then re-raise
+        # Catch failures and log more information, then re-raise
         try:
             compare_definition_to_actual(self.response['schema'], body)
         except AssertionError as e:

--- a/api_test/test_cases.py
+++ b/api_test/test_cases.py
@@ -95,14 +95,24 @@ class GetTestCase(test.TransactionTestCase):
         # Catch failures and print more information, then re-raise
         try:
             compare_definition_to_actual(self.response['schema'], body)
+        except AssertionError as e:
+            logger.debug('Failure comparing definition to actual:\n'
+                         'Documentation Schema (definition):\n'
+                         '{}\n'
+                         'Returned Response Body (actual):\n'
+                         '{}'
+                         .format(pformat(self.response['schema']), pformat(body)))
+            raise e
+
+        try:
             compare_actual_to_definition(self.response['schema'], body)
         except AssertionError as e:
-            print('Failure:\n'
-                  'Documentation Schema:\n'
-                  '{}\n'
-                  'Returned Response Body:\n'
-                  '{}'
-                  .format(pformat(self.response['schema']), pformat(body)))
+            logger.debug('Failure comparing actual to definition:\n'
+                         'Documentation Schema (definition):\n'
+                         '{}\n'
+                         'Returned Response Body (actual):\n'
+                         '{}'
+                         .format(pformat(self.response['schema']), pformat(body)))
             raise e
 
     def build_formatted_param(self, param_format, test_value):
@@ -130,4 +140,3 @@ class GetTestCase(test.TransactionTestCase):
 
     def setUp(self):
         super(GetTestCase, self).setUp()
-

--- a/api_test/test_cases.py
+++ b/api_test/test_cases.py
@@ -10,6 +10,7 @@ from rest_framework.test import APIClient
 from django.contrib.auth import get_user_model
 from utils import compare_definition_to_actual
 from utils import compare_actual_to_definition
+from pprint import pformat
 
 
 User = get_user_model()
@@ -90,8 +91,19 @@ class GetTestCase(test.TransactionTestCase):
         msg = 'code: %s, content: %s' % (code, content)
         self.assertEqual(code, self.response['status_code'], msg)
         body = json.loads(content)
-        compare_definition_to_actual(self.response['schema'], body)
-        compare_actual_to_definition(self.response['schema'], body)
+
+        # Catch failures and print more information, then re-raise
+        try:
+            compare_definition_to_actual(self.response['schema'], body)
+            compare_actual_to_definition(self.response['schema'], body)
+        except AssertionError as e:
+            print('Failure:\n'
+                  'Documentation Schema:\n'
+                  '{}\n'
+                  'Returned Response Body:\n'
+                  '{}'
+                  .format(pformat(self.response['schema']), pformat(body)))
+            raise e
 
     def build_formatted_param(self, param_format, test_value):
         # check if param is just explicitly defined


### PR DESCRIPTION
Please review: @ash6851 @spothero/backend 

This PR prints the expected schema from documentation, as well as the actual response body, when certain kinds of test failures happen. This should help with debugging. It produces test output like [this](https://gist.github.com/ellmanj/713fb48b5231a116df15e105a796620e).

This might not be the "right" way to do this. Probably better to use the nose [`formatFailure()`](http://nose.readthedocs.io/en/latest/plugins/interface.html#nose.plugins.base.IPluginInterface.formatFailure) function, but I was having a hard time getting that to work.